### PR TITLE
Include repository field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.2",
   "description": "Simple addon that injects typekit into index.html",
   "author": "",
-  "repository": "",
+  "repository": "git@github.com:sportly/ember-cli-typekit.git",
   "bugs": {
     "url": "https://github.com/sportly/ember-cli-typekit/issues"
   },


### PR DESCRIPTION
I am getting the following warning when using this library:
`npm WARN package.json ember-cli-typekit@0.0.2 No repository field.`
