### PR TITLE
Disable typekit per environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,28 @@ Add your typekit kitId to `config/environment.js` and you're good to go. A coupl
 ```js
 // environment.js
 
-    ENV.typekit: {
+    ENV.typekit = {
         kitId: 'xxxxxx'
     }
 ```
-
 
 ### Configuration Parameters
 
 * `kitId` (Default: `null`): The typekit kitId.
 * `sync` (Default: `false`): Inject the sync script instead of the default async script.
 * `timeout` (Default: `3000`): The default typekit timeout used when loading the async version. Param passed straight to typekit.
+
+## Disabling per environment
+
+You can disable injecting typekit into different environments by setting the
+disabled param to true:
+
+```js
+// environment.js
+
+if (environment === 'test') {
+  ENV.typekit = {
+    disabled: true
+  }
+}
+```

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = {
   name: 'ember-cli-typekit',
 
   contentFor: function(type, config) {
-    if (type === 'head-footer') {
+    if (type === 'head-footer' && !config.typekit.disabled) {
 
       if (config.typekit.sync === true) {
           return '<script src="//use.typekit.net/' + config.typekit.kitId + '.js"></script>' +


### PR DESCRIPTION
Why:

We'd like to be able to disable typekit in certain environments. For
instance, it is not a requirement when running tests.

This PR:

Adds a disabled flag to turn off injecting typekit and instructions to
the README.
